### PR TITLE
Update codeowners after the repository move.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brave-experiments/star-reviewers
+* @brave/star-reviewers


### PR DESCRIPTION
It seems team references must be within the same organization as the repo. This version should have the same members as in the experiments org.