### PR TITLE
Remove redundant into_iter calls.

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -20,7 +20,6 @@ impl RandomnessSampling {
   pub fn new(nm: &NestedMeasurement, epoch: u8) -> Self {
     Self {
       input: (0..nm.len())
-        .into_iter()
         .map(|i| nm.get_layer_as_bytes(i))
         .collect(),
       epoch,

--- a/src/format.rs
+++ b/src/format.rs
@@ -19,9 +19,7 @@ pub struct RandomnessSampling {
 impl RandomnessSampling {
   pub fn new(nm: &NestedMeasurement, epoch: u8) -> Self {
     Self {
-      input: (0..nm.len())
-        .map(|i| nm.get_layer_as_bytes(i))
-        .collect(),
+      input: (0..nm.len()).map(|i| nm.get_layer_as_bytes(i)).collect(),
       epoch,
     }
   }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -427,7 +427,6 @@ pub fn recover_partial_measurements(
         // been recovered
         if layer_idx + 1 < num_layers {
           let decrypted_messages = (0..indices.len())
-            .into_iter()
             .map(|i| {
               let ident = indices[i];
               let key = pms[i].get_next_layer_key().as_ref().unwrap();
@@ -441,12 +440,11 @@ pub fn recover_partial_measurements(
           next_layers.push(decrypted_messages);
         } else {
           (0..indices.len())
-            .into_iter()
             .for_each(|i| ident_nested_messages[indices[i]] = None);
         }
 
         // set the current partial outputs
-        (0..indices.len()).into_iter().for_each(|j| {
+        (0..indices.len()).for_each(|j| {
           let idx = indices[j];
           measurements[idx] = Ok(Some(FinalMeasurement::from(&pms[j])));
         });


### PR DESCRIPTION
The `Iterator` trait is already implemented for `std::ops::Range` so calling `.into_iter()` immediately after constructing a range literal does nothing.

Lint reported by clippy 1.69 nightly.