### PR TITLE
ci: switch to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,27 +25,19 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           components: clippy, rustfmt
           toolchain: ${{matrix.rust}}
-          override: true
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
       - name: Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt --all -- --check
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-targets
+        run: cargo build --release --all-targets
 
       - name: Clippy
         uses: actions-rs/clippy-check@v1
@@ -54,8 +46,5 @@ jobs:
           args: --release --all-targets -- -D warnings -A clippy::too_many_arguments
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
+        run: cargo test --release
 


### PR DESCRIPTION
The `actions-rs` suite of Github Actions scripts is very nice, but it has been unmaintained for the past couple of years. The toolchain action is now warning that it's using deprecated dependencies from github, which may be disabled later this year.

Switch to dtolnay/rust-toolchain to install the rust toolchain, but stick with actions-rs/clippy and actions-rs/audit for now since invoking the commands directly doesn't generate the nice reports.