### PR TITLE
Remove unnecessary into_iter() calls

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -244,7 +244,6 @@ mod tests {
       vec!["hello".as_bytes().to_vec(), "world".as_bytes().to_vec()];
     let random_fetcher = LocalFetcher::new();
     let messages: Vec<Vec<u8>> = (0..threshold - 1)
-      .into_iter()
       .map(|_| {
         let rrs = client::prepare_measurement(&measurement, epoch).unwrap();
         let req = client::construct_randomness_request(&rrs);
@@ -348,10 +347,8 @@ mod tests {
 
     // combine all measurements together
     let measurements: Vec<Vec<Vec<u8>>> = (0..total_num_measurements)
-      .into_iter()
       .map(|i| {
         (0..counts[i])
-          .into_iter()
           .map(|_| all_measurements[i].to_vec())
           .collect()
       })

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -777,9 +777,8 @@ mod tests {
   fn end_to_end_advanced(aux: Option<Vec<u8>>) {
     let threshold: usize = 3;
     let measurement_len = 5;
-    let mut full_input: Vec<Vec<u8>> = (0..5)
-      .map(|_| vec![1u8, 2u8, 3u8, 4u8, 5u8])
-      .collect();
+    let mut full_input: Vec<Vec<u8>> =
+      (0..5).map(|_| vec![1u8, 2u8, 3u8, 4u8, 5u8]).collect();
     full_input.extend(
       (0..3)
         .map(|_| vec![1u8, 2u8, 3u8, 5u8, 6u8])

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -756,7 +756,6 @@ mod tests {
     let num_clients = 3;
     let (outputs, measurements) = end_to_end(
       (0..num_clients)
-        .into_iter()
         .map(|_| vec![1u8, 2u8, 3u8, 4u8, 5u8])
         .collect(),
       &aux,
@@ -779,36 +778,30 @@ mod tests {
     let threshold: usize = 3;
     let measurement_len = 5;
     let mut full_input: Vec<Vec<u8>> = (0..5)
-      .into_iter()
       .map(|_| vec![1u8, 2u8, 3u8, 4u8, 5u8])
       .collect();
     full_input.extend(
       (0..3)
-        .into_iter()
         .map(|_| vec![1u8, 2u8, 3u8, 5u8, 6u8])
         .collect::<Vec<Vec<u8>>>(),
     );
     full_input.extend(
       (0..1)
-        .into_iter()
         .map(|_| vec![1u8, 2u8, 5u8, 6u8, 7u8])
         .collect::<Vec<Vec<u8>>>(),
     );
     full_input.extend(
       (0..2)
-        .into_iter()
         .map(|_| vec![2u8, 3u8, 4u8, 5u8, 6u8])
         .collect::<Vec<Vec<u8>>>(),
     );
     full_input.extend(
       (0..3)
-        .into_iter()
         .map(|_| vec![3u8, 4u8, 5u8, 6u8, 7u8])
         .collect::<Vec<Vec<u8>>>(),
     );
     full_input.extend(
       (0..1)
-        .into_iter()
         .map(|_| vec![3u8, 4u8, 5u8, 7u8, 8u8])
         .collect::<Vec<Vec<u8>>>(),
     );


### PR DESCRIPTION
The `Range` types are already iterable, so converting to an iterator before `map`, `filter`, etc. is an unnecessary step.

Addresses a lint from clippy 1.68.0 blocking ci.
