### PR TITLE
Downgrade rand_core from 0.6.4 to 0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version="1.0.158", features = ["derive"] }
 serde_json = "1.0.94"
 ppoprf = { git = "https://github.com/brave/sta-rs", rev = "fe9915741f7b6630" }
 sta-rs = { git = "https://github.com/brave/sta-rs", rev = "fe9915741f7b6630" }
-rand_core = "0.6.4"
+rand_core = "0.6.3"
 rand = { version = "0.8" }
 bincode = "1.3"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Temporarily downgrading rand_core to avoid upgrading various dependencies in brave-core before we switch over to Chromium's Rust build system