### PR TITLE
Bump MSRV to 1.67.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.59.0, stable]
+        rust: [1.67.1, stable]
         os: [ubuntu-20.04]
 
     env:


### PR DESCRIPTION
Raise the minimum-supported Rust version to a more recent release for compatibility with some dependencies. This is still compatible with active brave-core branches, but ahead of the current sta-rs default branch.