### PR TITLE
Downgrade minumum serde_json to v1.0.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.147", features = ["derive"] }
-serde_json = "1.0.79"
+serde_json = "1.0.78"
 ppoprf = { git = "https://github.com/brave/sta-rs", rev = "a0381f242314a906425e39f73656717e024636f3" }
 sta-rs = { git = "https://github.com/brave/sta-rs", rev = "a0381f242314a906425e39f73656717e024636f3" }
 rand_core = "0.6.3"


### PR DESCRIPTION
Allow compatibility with the version vendored in chromium r115. The changes are clippy lint fixes and accepting values with lone surrogate characters.