### PR TITLE
Update deps for publication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.78"
-ppoprf = { git = "https://github.com/brave/sta-rs", rev = "a0381f242314a906425e39f73656717e024636f3" }
-sta-rs = { git = "https://github.com/brave/sta-rs", rev = "a0381f242314a906425e39f73656717e024636f3" }
+ppoprf = "0.3.0"
+sta-rs = "0.2.1"
 rand_core = "0.6.3"
-rand = { version = "0.8" }
+rand = "0.8"
 bincode = "1.3"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/brave/constellation"
 keywords = ["crypto", "protocol", "privacy", "analytics"]
 categories = ["cryptography", "algorithms"]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.147", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.78"
 ppoprf = "0.3.0"
 sta-rs = "0.2.1"
-rand_core = "0.6.3"
-rand = "0.8"
+rand = { version = "0.8", features = ["getrandom"] }
 bincode = "1.3"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "star-constellation"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Alex Davidson <coela@alxdavids.xyz>"]
 license = "MPL-2.0"
 description = "Nested threshold aggregation built on the STAR protocol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,12 @@
 name = "star-constellation"
 version = "0.2.1"
 authors = ["Alex Davidson <coela@alxdavids.xyz>"]
-license = "MPL-2.0"
 description = "Nested threshold aggregation built on the STAR protocol"
+documentation = "https://docs.rs/star-constellation"
+repository = "https://github.com/brave/constellation"
+keywords = ["crypto", "protocol", "privacy", "analytics"]
+categories = ["cryptography", "algorithms"]
+license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -7,7 +7,7 @@ use sta_rs::{
   Message, MessageGenerator, Share, SingleMeasurement,
 };
 
-use rand_core::{OsRng, RngCore};
+use rand::{rngs::OsRng, RngCore};
 
 use crate::consts::*;
 use crate::Error;


### PR DESCRIPTION
- Bump version number to 0.2.1
- Add missing crate metadata for publication
- Refer to recently published dependencies through crates.io instead of git revisions
- Use `rand` crate over `rand_core`