### PR TITLE
Remove redundant into_iter

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -465,7 +465,7 @@ pub fn recover_partial_measurements(
 
   ident_nested_messages
     .into_iter()
-    .zip(measurements.into_iter())
+    .zip(measurements)
     .map(|(ident_nested_msg, measurement)| match measurement {
       Err(e) => Err(e),
       Ok(msmt) => {


### PR DESCRIPTION
The `zip` function argument is already bounded to a type implementing the `IntoIter` trait. We're passing a `Vec` which does implement that, so we don't need to make an explicit conversion.

Addresses a clippy warning with rust 1.72.0.