### PR TITLE
Reduce renovate noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Stay compatible with older deps for brave-core",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
The renovate bot prompts to update every dependency release, but for non-dev dependencies, we want to stay compatible with the older releases used by the brave browser, one of our downstream targets.

To reduce the noise, try to disable minor and tiny version bumps for those dependencies.

Also bumps the default config from `base` to `recommended` per validator lint.

Copied a similar change to the sta-rs repo.