### PR TITLE
github-actions: pin third-party action script versions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1
+      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,13 +25,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Toolchain
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e # v1
         with:
           components: clippy, rustfmt
           toolchain: ${{matrix.rust}}
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e207df5d269b42b69c8bc5101da26f7d31feddb4 # v2.6.2
 
       - name: Format
         run: cargo fmt --all -- --check
@@ -40,11 +40,10 @@ jobs:
         run: cargo build --release --all-targets
 
       - name: Clippy
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --release --all-targets -- -D warnings -A clippy::too_many_arguments
 
       - name: Test
         run: cargo test --release
-


### PR DESCRIPTION
Use a fixed revision instead of movable tags so we get a chance to review any changes. Renovate or Dependabot should prompt to bump these commit ids if there are new releases.

The actions-rs ci suite has been unmaintained for some years, so those are old, but widely used, revisions.

The rust-toolchain repo defines branches and tags aligned with each rust release, so one can use `@stable` or `@1.56.1` to specify action script and toolchain version on one line. This is incompatible with pinning the action script itself.

The instructions say to use `@master` in combination with a `with` clause specifying the toolchain version like we do to allow a matrix expansion. But if I've understood the current code correctly, that's not necessary because the version is just passed to `rustup` after some filtering.

Similar to https://github.com/brave/sta-rs/pull/311