### PR TITLE
github actions: Use rustup to install toolchain

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: Style
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '19 20 2 * *'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    env:
+      RUSTFLAGS: ''
+      CARGO_PROFILE_DEV_DEBUG: '0' # reduce size of target directory
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - name: Cache
+        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --release --all-targets -- -D warnings -A clippy::too_many_arguments

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Toolchain # possibly move away from this one
-        uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # v1
-        with:
-          components: clippy, rustfmt
-          toolchain: ${{matrix.rust}}
+      - name: Toolchain
+        run: |
+          rustup default ${{matrix.rust}}
+          rustup component add clippy rustfmt
 
       - name: Cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,24 +25,13 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Toolchain
-        run: |
-          rustup default ${{matrix.rust}}
-          rustup component add clippy rustfmt
+        run: rustup default ${{matrix.rust}}
 
       - name: Cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
 
-      - name: Format
-        run: cargo fmt --all -- --check
-
       - name: Build
         run: cargo build --release --all-targets
-
-      - name: Clippy
-        uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --release --all-targets -- -D warnings -A clippy::too_many_arguments
 
       - name: Test
         run: cargo test --release


### PR DESCRIPTION
Replace the dtolnay/rust-toolchain ci script with a direct call the to the `rustup` tool to build under the indicated release. This is part of the github actions runner image, so it's one less dependency we need to track in the repo.

Also splits the `fmt` and `clippy` steps into a parallel job for faster and cleaner feedback on style issues.