### PR TITLE
Remove unused httpmock dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,5 @@ bincode = "1.3"
 lazy_static = "1.4.0"
 
 [dev-dependencies]
-httpmock = "0.6.8"
 insta = "1.34.0"
 base64 = "0.21.5"


### PR DESCRIPTION
This was a dev-dependency used for testing, but references were removed with the API change for an external network implementation in 66c32f0a50bea661d7e3f57292009ac4e7717b22. The reference is no longer needed.