### PR TITLE
Raise MSRV to 1.72.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.67.1, stable]
+        rust: [1.72.1, stable]
         os: [ubuntu-20.04]
 
     env:


### PR DESCRIPTION
Update the minimum supported rust version to match the requirements of zeroize 1.8.0.

Fixes recent ci breakage.